### PR TITLE
feat: add disable-merge-to feature flag

### DIFF
--- a/proto/depot/cloud/v2/machine.proto
+++ b/proto/depot/cloud/v2/machine.proto
@@ -56,6 +56,8 @@ message RegisterMachineResponse {
     optional bool run_gc_before_start = 9;
     reserved 10;
     optional bool enable_scheduler_debug = 11;
+    // Turns off merging feature of buildkit.  Attempting to help GDC.
+    optional bool disable_merge_to = 12;
   }
 
   // Specifies sending buildkit profiling data to a remote endpoint.

--- a/src/gen/ts/depot/cloud/v2/machine_pb.ts
+++ b/src/gen/ts/depot/cloud/v2/machine_pb.ts
@@ -363,6 +363,13 @@ export class RegisterMachineResponse_BuildKitTask extends Message<RegisterMachin
    */
   enableSchedulerDebug?: boolean
 
+  /**
+   * Turns off merging feature of buildkit.  Attempting to help GDC.
+   *
+   * @generated from field: optional bool disable_merge_to = 12;
+   */
+  disableMergeTo?: boolean
+
   constructor(data?: PartialMessage<RegisterMachineResponse_BuildKitTask>) {
     super()
     proto3.util.initPartial(data, this)
@@ -381,6 +388,7 @@ export class RegisterMachineResponse_BuildKitTask extends Message<RegisterMachin
     {no: 8, name: 'disable_parallel_gzip', kind: 'scalar', T: 8 /* ScalarType.BOOL */, opt: true},
     {no: 9, name: 'run_gc_before_start', kind: 'scalar', T: 8 /* ScalarType.BOOL */, opt: true},
     {no: 11, name: 'enable_scheduler_debug', kind: 'scalar', T: 8 /* ScalarType.BOOL */, opt: true},
+    {no: 12, name: 'disable_merge_to', kind: 'scalar', T: 8 /* ScalarType.BOOL */, opt: true},
   ])
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RegisterMachineResponse_BuildKitTask {

--- a/src/tasks/buildkit.ts
+++ b/src/tasks/buildkit.ts
@@ -84,6 +84,10 @@ keepBytes = ${cacheSizeBytes}
     env.DEPOT_DISABLE_PARALLEL_GZIP = '1'
   }
 
+  if (task.disableMergeTo) {
+    env.DEPOT_DISABLE_MERGE_TO = '1'
+  }
+
   if (task.enableSchedulerDebug) {
     env.BUILDKIT_SCHEDULER_DEBUG = '1'
   }


### PR DESCRIPTION
disable mergeTo stops buildkit from merging build steps. We believe this may cut down on inconsistent graph state errors.