### PR TITLE
Simplify GC policy

### DIFF
--- a/src/tasks/buildkit.ts
+++ b/src/tasks/buildkit.ts
@@ -46,17 +46,18 @@ max-parallelism = 12
 [worker.containerd]
 enabled = false
 
-[[worker.oci.gcpolicy]]
-keepBytes = 10240000000 # 10 GB
-keepDuration = 604800 # 7 days: 3600 * 24 * 7
-filters = [
-  "type==source.local",
-  "type==exec.cachemount",
-  "type==source.git.checkout",
-]
+# [[worker.oci.gcpolicy]]
+# keepBytes = 10240000000 # 10 GB
+# keepDuration = 604800 # 7 days: 3600 * 24 * 7
+# filters = [
+#   "type==source.local",
+#   "type==exec.cachemount",
+#   "type==source.git.checkout",
+# ]
 
 [[worker.oci.gcpolicy]]
-keepBytes = ${cacheSizeBytes}
+all = true
+keepDuration = 1209600 # 14 days: 3600 * 24 * 14
 
 [[worker.oci.gcpolicy]]
 all = true


### PR DESCRIPTION
* Removes the filters on source and cache mounts
* Keeps the last 14 days of cache
* Keeps the max cache size targeting all types of cache