### PR TITLE
Use stargz snapshotter

### DIFF
--- a/src/tasks/buildkit.ts
+++ b/src/tasks/buildkit.ts
@@ -43,6 +43,7 @@ enabled = true
 gc = true
 gckeepstorage = ${cacheSizeBytes}
 max-parallelism = 12
+snapshotter = "stargz"
 
 [worker.containerd]
 enabled = false


### PR DESCRIPTION
Enables support for lazy-pulling images during build (https://github.com/moby/buildkit/blob/master/docs/stargz-estargz.md)