### PR TITLE
Run initial garbage collection in the background

### DIFF
--- a/src/tasks/ceph.ts
+++ b/src/tasks/ceph.ts
@@ -2,9 +2,7 @@ import {sleep} from '../utils/common'
 import {fstrim} from '../utils/mounts'
 
 export interface TrimParams {
-  buildkitStatus: {ready: boolean}
   signal: AbortSignal
-
   mounts: Mount[]
 }
 
@@ -12,17 +10,7 @@ export interface Mount {
   path: string
 }
 
-export async function trimLoop({buildkitStatus, signal, mounts}: TrimParams) {
-  // Wait for ready signal
-  while (true) {
-    if (signal.aborted) return
-
-    await sleep(1000)
-    if (buildkitStatus.ready) {
-      break
-    }
-  }
-
+export async function trimLoop({signal, mounts}: TrimParams) {
   // Trim every 2 minutes
   const TRIM_INTERVAL = 2 * 60 * 1000
   let nextRunTime = Date.now() + TRIM_INTERVAL

--- a/src/tasks/health.ts
+++ b/src/tasks/health.ts
@@ -6,7 +6,6 @@ import {DiskStats, stats} from '../utils/disk'
 import {client} from '../utils/grpc'
 
 export interface ReportHealthParams {
-  buildkitStatus: {ready: boolean}
   machineId: string
   signal: AbortSignal
   headers: HeadersInit
@@ -18,15 +17,9 @@ export interface Mount {
   path: string
 }
 
-export async function reportHealth({buildkitStatus, machineId, signal, headers, mounts}: ReportHealthParams) {
+export async function reportHealth({machineId, signal, headers, mounts}: ReportHealthParams) {
   while (true) {
     if (signal.aborted) return
-
-    // Wait for ready signal
-    if (!buildkitStatus.ready && !signal.aborted) {
-      await sleep(100)
-      continue
-    }
 
     await waitForBuildKitWorkers(signal)
 


### PR DESCRIPTION
We no longer need to block builds until the first GC run completes