### PR TITLE
Attempt to print `lsof` to find open files

### DIFF
--- a/src/utils/mounts.ts
+++ b/src/utils/mounts.ts
@@ -137,6 +137,7 @@ export async function unmountDevice(path: string) {
 
     // Print all processes that are using the mount.
     await execa('fuser', ['-vuMm', path], {reject: false, stdio: 'inherit'})
+    await execa('lsof', [path], {reject: false, stdio: 'inherit'})
     await sleep(500)
   }
 


### PR DESCRIPTION
Looks like `fuser` is pretty much going to always print that the kernel is using the mountpoint, this adds `lsof` to the mix to see what's open inside the mount