### PR TITLE
fix: add audience to complete JWT verification

### DIFF
--- a/src/utils/fly.ts
+++ b/src/utils/fly.ts
@@ -4,13 +4,20 @@ import {Agent, fetch} from 'undici'
 export async function getFlyToken(): Promise<string> {
   try {
     const res = await fetch('http://localhost/v1/tokens/oidc', {
-      signal: AbortSignal.timeout(1000),
+      signal: AbortSignal.timeout(5000),
+      method: 'POST',
+      body: JSON.stringify({aud: 'https://depot.dev'}),
+      headers: {'Content-Type': 'application/json'},
       dispatcher: new Agent({
         connect: {
           socketPath: '/.fly/api',
         },
       }),
     })
+
+    if (!res.ok) {
+      throw new Error(`unable to get oidc token: ${res.statusText}`)
+    }
 
     const data = await res.text()
     return data


### PR DESCRIPTION
Fly's oidc token API requires POST.  Additionally, we need the `https://depot.dev` audience as part of token verification.