### PR TITLE
feat: report statistics of cache path

### DIFF
--- a/proto/depot/cloud/v3/machine.proto
+++ b/proto/depot/cloud/v3/machine.proto
@@ -121,7 +121,7 @@ message PingMachineHealthRequest {
 }
 
 message DiskSpace {
-  string device = 1;
+  reserved 1;
   string path = 2;
   int64 free_mb = 3;
   int64 total_mb = 4;

--- a/src/gen/ts/depot/cloud/v3/machine_pb.ts
+++ b/src/gen/ts/depot/cloud/v3/machine_pb.ts
@@ -795,11 +795,6 @@ export class PingMachineHealthRequest extends Message<PingMachineHealthRequest> 
  */
 export class DiskSpace extends Message<DiskSpace> {
   /**
-   * @generated from field: string device = 1;
-   */
-  device = ''
-
-  /**
    * @generated from field: string path = 2;
    */
   path = ''
@@ -832,7 +827,6 @@ export class DiskSpace extends Message<DiskSpace> {
   static readonly runtime: typeof proto3 = proto3
   static readonly typeName = 'depot.cloud.v3.DiskSpace'
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    {no: 1, name: 'device', kind: 'scalar', T: 9 /* ScalarType.STRING */},
     {no: 2, name: 'path', kind: 'scalar', T: 9 /* ScalarType.STRING */},
     {no: 3, name: 'free_mb', kind: 'scalar', T: 3 /* ScalarType.INT64 */},
     {no: 4, name: 'total_mb', kind: 'scalar', T: 3 /* ScalarType.INT64 */},

--- a/src/tasks/buildkit.ts
+++ b/src/tasks/buildkit.ts
@@ -250,7 +250,7 @@ keepBytes = ${cacheSizeBytes}
   try {
     await Promise.all([
       buildkit,
-      reportHealth({machineId, signal, headers, mounts: task.mounts}),
+      reportHealth({machineId, signal, headers, path: '/var/lib/buildkit'}),
       reportUsage({machineId, signal, headers}),
     ])
   } catch (error) {

--- a/src/tasks/engine.ts
+++ b/src/tasks/engine.ts
@@ -110,7 +110,7 @@ export async function startEngine(message: RegisterMachineResponse, task: Regist
   try {
     await Promise.all([
       engine,
-      reportEngineHealth({machineId, signal, headers, mounts: task.mounts}),
+      reportEngineHealth({machineId, signal, headers, path: '/var/lib/engine'}),
       // reportUsage({machineId, signal, headers}),
     ])
   } catch (error) {

--- a/src/tasks/health.ts
+++ b/src/tasks/health.ts
@@ -1,23 +1,16 @@
-import {PlainMessage} from '@bufbuild/protobuf'
 import {execa} from 'execa'
-import {DiskSpace} from '../gen/ts/depot/cloud/v3/machine_pb'
 import {sleep} from '../utils/common'
-import {DiskStats, stats} from '../utils/disk'
+import {stats} from '../utils/disk'
 import {client} from '../utils/grpc'
 
 export interface ReportHealthParams {
   machineId: string
   signal: AbortSignal
   headers: HeadersInit
-  mounts: Mount[]
-}
-
-export interface Mount {
-  device: string
   path: string
 }
 
-export async function reportHealth({machineId, signal, headers, mounts}: ReportHealthParams) {
+export async function reportHealth({machineId, signal, headers, path}: ReportHealthParams) {
   while (true) {
     if (signal.aborted) return
 
@@ -27,23 +20,20 @@ export async function reportHealth({machineId, signal, headers, mounts}: ReportH
       while (true) {
         if (signal.aborted) return
 
-        const disk_stats = await Promise.all(mounts.map(({device, path}) => stats(device, path)))
-        const disks: PlainMessage<DiskSpace>[] = disk_stats
-          .filter((item: DiskStats | undefined): item is DiskStats => {
-            return item !== undefined
-          })
-          .map(({device, path, freeMb, totalMb, freeInodes, totalInodes}) => {
-            return {
-              device,
-              path,
-              freeMb,
-              totalMb,
-              freeInodes,
-              totalInodes,
-            }
-          })
+        const disk_stats = await stats(path)
+        const disk_space = disk_stats
+          ? [
+              {
+                path,
+                freeMb: disk_stats.freeMb,
+                totalMb: disk_stats.totalMb,
+                freeInodes: disk_stats.freeInodes,
+                totalInodes: disk_stats.totalInodes,
+              },
+            ]
+          : undefined
 
-        await client.pingMachineHealth({machineId, disks}, {headers, signal})
+        await client.pingMachineHealth({machineId, disks: disk_space}, {headers, signal})
         await sleep(1000)
       }
     } catch (error) {

--- a/src/utils/disk.ts
+++ b/src/utils/disk.ts
@@ -1,7 +1,6 @@
 import {execa} from 'execa'
 
 export interface DiskStats {
-  device: string
   path: string
   freeMb: bigint
   totalMb: bigint
@@ -9,14 +8,13 @@ export interface DiskStats {
   totalInodes: bigint
 }
 
-export async function stats(device: string, path: string): Promise<DiskStats | undefined> {
+export async function stats(path: string): Promise<DiskStats | undefined> {
   try {
     const {exitCode, stdout} = await execa('stat', ['-f', '-c', '%S %a %b %d %c', path])
     if (exitCode == 0) {
       const output = stdout as string
       const [blockSize, freeBlocks, totalBlocks, freeInodes, totalInodes] = output.split(' ')
       const diskStats = {
-        device,
         path,
         freeMb: (BigInt(blockSize) * BigInt(freeBlocks)) / BigInt(1024) / BigInt(1024),
         totalMb: (BigInt(blockSize) * BigInt(totalBlocks)) / BigInt(1024) / BigInt(1024),


### PR DESCRIPTION
Rather than using the device mounts, we use the
already hard-coded cache paths.

This is useful in the situation when a task does not have mounts at all.